### PR TITLE
Update Dockerfile for compatibility with cbt-dev versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-alpine3.14
+FROM ruby:2.6-alpine3.13
 
 RUN apk update 
 RUN apk upgrade


### PR DESCRIPTION
The docker version (19) on cbt-dev has an incompatibility with alpine3.14 that is /likely/ the cause of the ruby autograder error on the server; downgrade to alpine3.13 is the likely-best workaround in our case:

https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2